### PR TITLE
[do not merge] adding mason-installed lib and include dirs

### DIFF
--- a/pynini.egg-info/PKG-INFO
+++ b/pynini.egg-info/PKG-INFO
@@ -6,6 +6,7 @@ Home-page: http://pynini.opengrm.org/
 Author: Kyle Gorman
 Author-email: kbg@google.com
 License: UNKNOWN
+Description-Content-Type: UNKNOWN
 Description: UNKNOWN
 Keywords: natural language processing,speech recognition,machine learning
 Platform: UNKNOWN

--- a/pynini.egg-info/SOURCES.txt
+++ b/pynini.egg-info/SOURCES.txt
@@ -7,6 +7,7 @@ NEWS
 README.rst
 pynini.pdf
 pynini_test.py
+setup.cfg
 setup.py
 pynini.egg-info/PKG-INFO
 pynini.egg-info/SOURCES.txt

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ if platform.system() == 'Linux':
     OS='linux'
 elif platform.system() == 'Darwin':
     OS='osx'
+    from distutils import sysconfig
+    config_vars = sysconfig.get_config_vars()
+    config_vars['LDSHARED'] = config_vars['LDSHARED'].replace('-bundle', '-dynamiclib')
 
 COMPILE_ARGS = ["-std=c++11",
                 "-Wno-unused-function",


### PR DESCRIPTION
Opening this PR for instructive purposes.  This is just to show how [mason](https://github.com/mapbox/mason) can be used to install Pynini's C++ dependencies.  The advantage of using mason is similar to the advantages of virtual environments: nothing depends on the state of the system or its shared libraries. The dependencies can be installed and even interlinked local to the project, making it easy to build/clean/update.

The steps to install become: 

1. clone mason locally (you can also [use submodule](https://github.com/mapbox/mason#submodule) or do a [simple curl install](https://github.com/mapbox/mason#curl-install))

```
cd /path/to/Pynini
git clone git@github.com:mapbox/mason.git .mason
```

2. install re2 and openfst. If you need updated versions of either package, they need to be added to mason as a PR.  https://github.com/mapbox/mason/pull/580 is an example of updating OpenFST, and should illustrate what needs to be done. Contact me for help if anything's not clear, though.

```
.mason/mason install re2 2018-08-01
.mason/mason install openfst 1.6.7
```

This will create a `mason_packages` folder in the pwd, structured similarly to this (example from a laptop running OSX):

```
mason_packages/
└── osx-x86_64
    ├── openfst
    │   └── 1.6.7
    └── re2
        └── 2017-08-01
```

3. The changes to `setup.py` in this PR now allow you to make use of the mason-installed header files and libraries, so you can continue with installation as directed in the Pynini documentation.