### PR TITLE
Adds a minimal pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["Cython==0.29.32", "setuptools>=32.0.0", "wheel"]


### PR DESCRIPTION
Solves #30
Using pyproject.toml solves the bootstrap problem with Cython and makes the project build in isolation, as required by certain build systems (e.g. poetry).