### PR TITLE
Stopgap release v.2.1.5.post1.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+v. 2.1.5.post1 (compatible with OpenFst 1.8.2)
+========================================
+
+* Added `pyproject.toml` support
+* Sets minimum MacOS version to 10.12
+
 v. 2.1.5 (compatible with OpenFst 1.8.2)
 ========================================
 

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,111 +1,19 @@
 Metadata-Version: 2.1
 Name: pynini
-Version: 2.1.5
+Version: 2.1.5.post1
 Summary: Finite-state grammar compilation
 Home-page: http://pynini.opengrm.org
-Author: Kyle Gorman
+Author: Kyle Gorman <kbg@google.com>
 Author-email: kbg@google.com
 License: Apache 2.0
-Description: # OpenGrm Pynini
-        
-        This is a a Python extension module for compiling, optimizing and applying
-        grammar rules. Rules can be compiled into weighted finite state transducers,
-        pushdown transducers, or multi-pushdown transducers. It uses OpenFst
-        finite-state transducers (FSTs) and FST archives (FArs) as inputs and outputs.
-        
-        This library is primarily developed by [Kyle Gorman](mailto:kbg@google.com).
-        
-        If you use Pynini in your research, we would appreciate if you cite the
-        following paper:
-        
-        > K. Gorman. 2016.
-        > [Pynini: A Python library for weighted finite-state grammar compilation](http://openfst.cs.nyu.edu/twiki/pub/GRM/Pynini/pynini-paper.pdf).
-        > In *Proc. ACL Workshop on Statistical NLP and Weighted Automata*, 75-80.
-        
-        (Note that some of the code samples in the paper are now out of date and not
-        expected to work.)
-        
-        ## Dependencies
-        
-        -   A standards-compliant C++17 compiler (GCC \>= 7 or Clang \>= 700)
-        -   The compatible recent version of [OpenFst](http://openfst.org) (see
-            [`NEWS`](NEWS) for this) built with the `grm` extensions (i.e., built with
-            `./configure --enable-grm`) and headers
-        -   [Python 3.6+](https://www.python.org) and headers
-        
-        ## Installation instructions
-        
-        There are various ways to install Pynini depending on your platform.
-        
-        ### Windows
-        
-        While Pynini is neither designed for nor tested on Windows, it can be installed
-        using the
-        [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
-        (WSL). Simply enter the WSL environment and follow the Linux instructions below.
-        
-        ### MacOS
-        
-        The pre-compiled library can be installed from
-        [`conda-forge`](https://conda-forge.org/) by running `conda install -c
-        conda-forge pynini`.
-        
-        Alternatively, one can build from source from [PyPI](https://pypi.org/) by
-        running `pip install pynini`.
-        
-        Finally, one can use [Bazel](https://bazel.build) to build from source by
-        running `bazel build //:all` anywhere in the source tree.
-        
-        ### Linux
-        
-        The pre-compiled library can be installed from
-        [`conda-forge`](https://conda-forge.org/) by running `conda install -c
-        conda-forge pynini`.
-        
-        Alternatively, one can install a pre-compiled
-        [`manylinux`](https://github.com/pypa/manylinux) wheel from
-        [PyPI](https://pypi.org/) by running `pip install pynini`. This will install the
-        pre-compiled `manylinux` wheel (if available for the release and compatible with
-        your platform), and build and install from source if not. Unlike the
-        `conda-forge` option above, which also installs [OpenFst](http://openfst.org/)
-        and [Graphviz](https://graphviz.org/), this does not install the OpenFst or
-        Graphviz command-line tools. See the enclosed
-        [`Dockerfile`](third_party/Dockerfile) for instructions for building and
-        deploying `manylinux` wheels.
-        
-        Finally, one can use [Bazel](https://bazel.build) to build from source by
-        running `bazel build //:all` anywhere in the source tree.
-        
-        ## Testing
-        
-        To confirm successful installation, run `pip install -r requirements`, then
-        `python tests/pynini_test.py`. If all tests pass, the final line will read `OK`.
-        
-        ## Python version support
-        
-        Pynini 2.0.0 and onward support Python 3. Pynini 2.1 versions (onward) drop
-        Python 2 support.
-        
-        # License
-        
-        Pynini is released under the Apache license. See [`LICENSE`](LICENSE) for more
-        information.
-        
-        # Interested in contributing?
-        
-        See [`CONTRIBUTING`](CONTRIBUTING) for more information.
-        
-        # Mandatory disclaimer
-        
-        This is not an official Google product.
-        
-Keywords: natural language processing,speech recognition,machine learning
-Platform: UNKNOWN
+Project-URL: homepage, https://pynini.opengrm.org
+Keywords: computational linguistics,morphology,natural language processing,language
 Classifier: Programming Language :: Python :: 3.6
 Classifier: Programming Language :: Python :: 3.7
 Classifier: Programming Language :: Python :: 3.8
 Classifier: Programming Language :: Python :: 3.9
 Classifier: Programming Language :: Python :: 3.10
+Classifier: Programming Language :: Python :: 3.11
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Environment :: Other Environment
 Classifier: Environment :: Console
@@ -116,4 +24,100 @@ Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Classifier: Topic :: Text Processing :: Linguistic
 Classifier: Topic :: Scientific/Engineering :: Artificial Intelligence
 Classifier: Topic :: Scientific/Engineering :: Mathematics
+Requires-Python: >=3.6
 Description-Content-Type: text/markdown
+License-File: LICENSE
+License-File: AUTHORS
+
+# OpenGrm Pynini
+
+This is a a Python extension module for compiling, optimizing and applying
+grammar rules. Rules can be compiled into weighted finite state transducers,
+pushdown transducers, or multi-pushdown transducers. It uses OpenFst
+finite-state transducers (FSTs) and FST archives (FArs) as inputs and outputs.
+
+This library is primarily developed by [Kyle Gorman](mailto:kbg@google.com).
+
+If you use Pynini in your research, we would appreciate if you cite the
+following paper:
+
+> K. Gorman. 2016.
+> [Pynini: A Python library for weighted finite-state grammar compilation](http://openfst.cs.nyu.edu/twiki/pub/GRM/Pynini/pynini-paper.pdf).
+> In *Proc. ACL Workshop on Statistical NLP and Weighted Automata*, 75-80.
+
+(Note that some of the code samples in the paper are now out of date and not
+expected to work.)
+
+## Dependencies
+
+-   A standards-compliant C++17 compiler (GCC \>= 7 or Clang \>= 700)
+-   The compatible recent version of [OpenFst](http://openfst.org) (see
+    [`NEWS`](NEWS) for this) built with the `grm` extensions (i.e., built with
+    `./configure --enable-grm`) and headers
+-   [Python 3.6+](https://www.python.org) and headers
+
+## Installation instructions
+
+There are various ways to install Pynini depending on your platform.
+
+### Windows
+
+While Pynini is neither designed for nor tested on Windows, it can be installed
+using the
+[Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+(WSL). Simply enter the WSL environment and follow the Linux instructions below.
+
+### MacOS
+
+The pre-compiled library can be installed from
+[`conda-forge`](https://conda-forge.org/) by running `conda install -c
+conda-forge pynini`.
+
+Alternatively, one can build from source from [PyPI](https://pypi.org/) by
+running `pip install pynini`.
+
+Finally, one can use [Bazel](https://bazel.build) to build from source by
+running `bazel build //:all` anywhere in the source tree.
+
+### Linux
+
+The pre-compiled library can be installed from
+[`conda-forge`](https://conda-forge.org/) by running `conda install -c
+conda-forge pynini`.
+
+Alternatively, one can install a pre-compiled
+[`manylinux`](https://github.com/pypa/manylinux) wheel from
+[PyPI](https://pypi.org/) by running `pip install pynini`. This will install the
+pre-compiled `manylinux` wheel (if available for the release and compatible with
+your platform), and build and install from source if not. Unlike the
+`conda-forge` option above, which also installs [OpenFst](http://openfst.org/)
+and [Graphviz](https://graphviz.org/), this does not install the OpenFst or
+Graphviz command-line tools. See the enclosed
+[`Dockerfile`](third_party/Dockerfile) for instructions for building and
+deploying `manylinux` wheels.
+
+Finally, one can use [Bazel](https://bazel.build) to build from source by
+running `bazel build //:all` anywhere in the source tree.
+
+## Testing
+
+To confirm successful installation, run `pip install -r requirements`, then
+`python tests/pynini_test.py`. If all tests pass, the final line will read `OK`.
+
+## Python version support
+
+Pynini 2.0.0 and onward support Python 3. Pynini 2.1 versions (onward) drop
+Python 2 support.
+
+# License
+
+Pynini is released under the Apache license. See [`LICENSE`](LICENSE) for more
+information.
+
+# Interested in contributing?
+
+See [`CONTRIBUTING`](CONTRIBUTING) for more information.
+
+# Mandatory disclaimer
+
+This is not an official Google product.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+# Copyright 2016-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For general information on the Pynini grammar compilation library, see
+# pynini.opengrm.org.
+
+[build-system]
+requires = ["Cython==0.29.32", "setuptools>=32.0.0", "wheel"]
+
+[project]
+name = "pynini"
+version = "2.1.5.post1"
+description = "Finite-state grammar compilation"
+readme = "README.md"
+requires-python = ">= 3.6"
+license = { text = "Apache 2.0" }
+authors = [{name = "Kyle Gorman <kbg@google.com>"}]
+keywords = [
+    "computational linguistics",
+    "morphology",
+    "natural language processing",
+    "language",
+]
+classifiers = [
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Other Environment",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Text Processing :: Linguistic",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Mathematics",
+]
+
+[project.urls]
+homepage = "https://pynini.opengrm.org"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 Google LLC
+# Copyright 2016-2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -126,7 +126,6 @@ def main() -> None:
           "Topic :: Scientific/Engineering :: Mathematics",
       ],
       license="Apache 2.0",
-      install_requires=["Cython >= 0.29"],
       ext_modules=cythonize([pywrapfst, pynini]),
       packages=find_packages(exclude=["scripts", "tests"]),
       package_data={


### PR DESCRIPTION
* Added `pyproject.toml` support; closes #30
* Sets minimum MacOS version to 10.12; closes #54